### PR TITLE
Split log data on spaces, only grab at most two elements when splitting key=val pairs.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -104,7 +104,7 @@ class App < Sinatra::Base
           next if matches.nil? || matches.length < 5
 
           ps   = matches[3].split('.').first
-          data = Hash[ matches[4].split(" ").map{|j| j.split("=")} ]
+          data = Hash[ matches[4].split(/\s+/).map{|j| j.split("=", 2)} ]
 
           parsed_line = {}
 


### PR DESCRIPTION
The latter protects against odd cases where two log messages are munged together, resulting in something like foo=bar=baz.
