### PR TITLE
Skip the line if it doesn't contain key value pairs

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -134,7 +134,9 @@ class App < Sinatra::Base
             next if matches.nil? || matches.length < 5
 
             ps   = matches[3].split('.').first
-            data = Hash[ matches[4].split(/\s+/).map{|j| j.split("=", 2)} ]
+            key_value_pairs = matches[4].split(/\s+/).map{|j| j.split("=", 2)}
+            next unless key_value_pairs.all?{ |pair| pair.size == 2}
+            data = Hash[ key_value_pairs ]
 
             parsed_line = {}
 


### PR DESCRIPTION
When we split on = there should be a key on the left and
a value on the right

This makes parsing work on Ruby 2.0 which otherwise
raises ArgumentError when the array passed to Hash#[]
includes an empty array
