### PR TITLE
Fix FloatDomainError for Memory Usage

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -72,6 +72,7 @@ class App < Sinatra::Base
       formation = api.get_formation(name).body
       web = formation.select{|f| f["type"] == "web" }.first || {}
       size = web.fetch("size", 1)
+      size.to_i
     rescue Heroku::API::Errors::Forbidden, Heroku::API::Errors::NotFound
       halt(404)
     end


### PR DESCRIPTION
The Heroku API returns a `'1'` or `'2'` based on the web dyno's size and the result was not being typecast into an integer. Multiplying the string by the `BASE_DYNO_SIZE` would raise `FloatDomainError: Infinity` when trying to convert it to a human readable format. The visible result was a blank value for total available memory.

This fixes that. :+1: 
